### PR TITLE
Add BuildArgs for Docker build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@
 # license agreements; and to You under the Apache License, Version 2.0.
 
 sudo: required
-group: deprecated-2017Q3
+dist: xenial
 language: scala
 scala:
 - 2.12.7
+jdk:
+- openjdk8
 services:
 - docker
 

--- a/core/java8/Dockerfile
+++ b/core/java8/Dockerfile
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk8-openj9:jdk8u162-b12_openj9-0.8.0
+ARG ADOPTOPENJDK_TARGET_REGISTRY=adoptopenjdk
+FROM ${ADOPTOPENJDK_TARGET_REGISTRY}/openjdk8-openj9:jdk8u192-b12_openj9-0.11.0
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales \

--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -54,7 +54,7 @@ if(project.hasProperty('dockerHost')) {
 }
 
 if(project.hasProperty('dockerBuildArgs')) {
-    dockerBuildArgs.each { arg  ->
+    dockerBuildArgs.tokenize().each { arg  ->
         dockerBuildArg += ['--build-arg', arg]
     }
 }


### PR DESCRIPTION
Version bump for the AdoptOpenJDK image to bring it to the latest released version and...

The processing of the `--buildArgs` option in docker.gradle seems to have been broken for a long time.  I've fixed that problem to give the option of using an ARG to specify a docker repository for AdoptOpenJDK downloads.  Why?  I've been putting together a repository of multi-architecture images that _may_ be ahead of the core repository (including an Alpine image if anyone's interested).

This change should be transparent to most users because the ARG in question defaults to the docker.io library.