### PR TITLE
Update to AdoptOpenJDK's JDK8-OpenJ9 Critical Patch Update v0.15.1

### DIFF
--- a/core/java8/Dockerfile
+++ b/core/java8/Dockerfile
@@ -27,8 +27,8 @@ ENV LANG="en_US.UTF-8" \
 	LANGUAGE="en_US:en" \
 	LC_ALL="en_US.UTF-8" \
 	VERSION=8 \
-	UPDATE=162 \
-	BUILD=12
+	UPDATE=222 \
+	BUILD=10
 
 ADD proxy /javaAction
 

--- a/core/java8/Dockerfile
+++ b/core/java8/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # Use AdoptOpenJDK's JDK8, OpenJ9 Critical Patch Update (CPU) release version 0.15.1
-FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u222-b10_openj9-0.15.1
+FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u222-b10_openj9-0.15.1
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales \

--- a/core/java8/Dockerfile
+++ b/core/java8/Dockerfile
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u212-b04_openj9-0.14.2
+# Use AdoptOpenJDK's JDK8, OpenJ9 Critical Patch Update (CPU) release version 0.15.1
+FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u222-b10_openj9-0.15.1
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales \

--- a/core/java8actionloop/Dockerfile
+++ b/core/java8actionloop/Dockerfile
@@ -17,9 +17,8 @@
 FROM golang:1.12 as builder
 RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main
 
-FROM adoptopenjdk/openjdk8:x86_64-ubuntu-jdk8u212-b04
 # Use AdoptOpen JDK8, OpenJ9 release version 0.15.1
-#FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u222-b10_openj9-0.15.1
+FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u222-b10_openj9-0.15.1
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales python vim \

--- a/core/java8actionloop/Dockerfile
+++ b/core/java8actionloop/Dockerfile
@@ -17,7 +17,8 @@
 FROM golang:1.12 as builder
 RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main
 
-FROM adoptopenjdk/openjdk8:x86_64-ubuntu-jdk8u212-b04
+# Use AdoptOpen JDK8, OpenJ9 Critical Patch Update (CPU) release version 0.15.1
+FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u222-b10_openj9-0.15.1
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales python vim \

--- a/core/java8actionloop/Dockerfile
+++ b/core/java8actionloop/Dockerfile
@@ -17,8 +17,9 @@
 FROM golang:1.12 as builder
 RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main
 
-# Use AdoptOpen JDK8, OpenJ9 Critical Patch Update (CPU) release version 0.15.1
-FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u222-b10_openj9-0.15.1
+#FROM adoptopenjdk/openjdk8:x86_64-ubuntu-jdk8u212-b04
+# Use AdoptOpen JDK8, OpenJ9 release version 0.15.1
+#FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u222-b10_openj9-0.15.1
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales python vim \

--- a/core/java8actionloop/Dockerfile
+++ b/core/java8actionloop/Dockerfile
@@ -17,9 +17,9 @@
 FROM golang:1.12 as builder
 RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main
 
-#FROM adoptopenjdk/openjdk8:x86_64-ubuntu-jdk8u212-b04
+FROM adoptopenjdk/openjdk8:x86_64-ubuntu-jdk8u212-b04
 # Use AdoptOpen JDK8, OpenJ9 release version 0.15.1
-#FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jre8u222-b10_openj9-0.15.1
+#FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u222-b10_openj9-0.15.1
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales python vim \
@@ -30,8 +30,8 @@ ENV LANG="en_US.UTF-8" \
 	LANGUAGE="en_US:en" \
 	LC_ALL="en_US.UTF-8" \
 	VERSION=8 \
-	UPDATE=212 \
-	BUILD=3
+	UPDATE=222 \
+	BUILD=10
 
 RUN locale-gen en_US.UTF-8 ;\
     mkdir -p /javaAction/action /usr/java/src /usr/java/lib

--- a/core/java8actionloop/build.gradle
+++ b/core/java8actionloop/build.gradle
@@ -15,5 +15,5 @@
  * limitations under the License.
  */
 
-ext.dockerImageName = 'actionloop-java-v8'
+ext.dockerImageName = 'actionloop-java-v8:nightly'
 apply from: '../../gradle/docker.gradle'

--- a/core/java8actionloop/build.gradle
+++ b/core/java8actionloop/build.gradle
@@ -15,5 +15,5 @@
  * limitations under the License.
  */
 
-ext.dockerImageName = 'actionloop-java-v8:nightly'
+ext.dockerImageName = 'actionloop-java-v8'
 apply from: '../../gradle/docker.gradle'


### PR DESCRIPTION
Please see "what's new" here:
https://www.eclipse.org/openj9/oj9_whatsnew.html

Release notes:
https://www.eclipse.org/openj9/docs/version0.15/