### PR TITLE
Get latest security fixes with every build.

### DIFF
--- a/core/java8/CHANGELOG.md
+++ b/core/java8/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 # Java 8 OpenWhisk Runtime Container
 
+## 1.15.0 (next release)
+  - Include latest security fixes with every build.
+
 ## 1.14.0
   - Support for __OW_ACTION_VERSION (openwhisk/4761)
   - adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u222-b10_openj9-0.15.1

--- a/core/java8/Dockerfile
+++ b/core/java8/Dockerfile
@@ -18,10 +18,14 @@
 # Use AdoptOpenJDK's JDK8, OpenJ9 Critical Patch Update (CPU) release version 0.15.1
 FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u222-b10_openj9-0.15.1
 
-RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
-	&& apt-get install -y --no-install-recommends locales \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& locale-gen en_US.UTF-8
+RUN rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && apt-get update \
+    && apt-get -y --no-install-recommends upgrade \
+    && apt-get -y --no-install-recommends install locales \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && locale-gen en_US.UTF-8
 
 ENV LANG="en_US.UTF-8" \
 	LANGUAGE="en_US:en" \

--- a/core/java8actionloop/CHANGELOG.md
+++ b/core/java8actionloop/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 # Java 8 OpenWhisk Runtime Container
 
+## 1.15.0 (next release)
+  - Include latest security fixes with every build.
+
 ## 1.14.0
   - Initial release of actionloop-based Java Action
   - adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u222-b10_openj9-0.15.1

--- a/core/java8actionloop/Dockerfile
+++ b/core/java8actionloop/Dockerfile
@@ -34,10 +34,14 @@ FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u222-b10_openj9-0.15.1
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release
 
-RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
-	&& apt-get install -y --no-install-recommends locales python vim \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& locale-gen en_US.UTF-8
+RUN rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && apt-get update \
+    && apt-get -y --no-install-recommends upgrade \
+    && apt-get -y --no-install-recommends install locales python vim \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && locale-gen en_US.UTF-8
 
 ENV LANG="en_US.UTF-8" \
 	LANGUAGE="en_US:en" \


### PR DESCRIPTION
  - Add 'apt-get upgrade' to the image builds to include security fixes with each build in case the used base image is not updated frequently.
    In case the base image is updated frequently, the 'apt-get upgrade' is a no operation. If not it will catch the security updates available since the last update of the base image.