### PR TITLE
Update Base image to fix vulnerabilities

### DIFF
--- a/core/java8/CHANGELOG.md
+++ b/core/java8/CHANGELOG.md
@@ -18,6 +18,8 @@
 -->
 
 # Java 8 OpenWhisk Runtime Container
+# 1.19.0
+ - Use adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u332-b09_openj9-0.32.0
 
 ## 1.18.0
   - Use adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u322-b06_openj9-0.30.0

--- a/core/java8/Dockerfile
+++ b/core/java8/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # Use AdoptOpenJDK's JDK8, OpenJ9, ubuntu
-FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u322-b06_openj9-0.30.0
+FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u332-b09_openj9-0.32.0
 
 RUN rm -rf /var/lib/apt/lists/* \
     && apt-get clean \

--- a/core/java8actionloop/CHANGELOG.md
+++ b/core/java8actionloop/CHANGELOG.md
@@ -18,6 +18,8 @@
 -->
 
 # Java 8 OpenWhisk Runtime Container
+# 1.19.0
+ - Use adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u332-b09_openj9-0.32.0
 
 ## 1.18.0
   - Use adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u322-b06_openj9-0.30.0

--- a/core/java8actionloop/Dockerfile
+++ b/core/java8actionloop/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -sL \
   && GO111MODULE=on go build -o /bin/proxy
 
 # Use AdoptOpenJDK's JDK8, OpenJ9, ubuntu
-FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u322-b06_openj9-0.30.0
+FROM adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u332-b09_openj9-0.32.0
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=release


### PR DESCRIPTION
`adoptopenjdk/openjdk8-openj9:x86_64-ubuntu-jdk8u332-b09_openj9-0.32.0`