### PR TITLE
Update Travis Distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@
 #
 
 sudo: required
-dist: bionic 
+dist: focal 
 language: java
-jdk: openjdk8
+jdk: openjdk11
 services:
 - docker
 # required to support multi-stage build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 #
 
 sudo: required
-dist: focal 
+dist: bionic 
 language: java
 jdk: openjdk8
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 #
 
 sudo: required
-dist: xenial
+dist: focal 
 language: java
 jdk: openjdk8
 services:


### PR DESCRIPTION
Updating Travis distribution to current Ubuntu LTS version 20.04 (Focal)