### PR TITLE
Update gradle-scalafmt to 1.5.1 to fix build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,10 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath "cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
+        classpath "gradle.plugin.cz.alenkacz:gradle-scalafmt:${gradle.scalafmt.version}"
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,7 +34,7 @@ gradle.ext.scala = [
 ]
 
 gradle.ext.scalafmt = [
-    version: '1.5.0',
+    version: '1.5.1',
     config: new File(rootProject.projectDir, '.scalafmt.conf')
 ]
 


### PR DESCRIPTION
- The 'cz.alenkacz:gradle-scalafmt' module could not be found anymore. Had to change the name to 'gradle.plugin.cz.alenkacz:gradle-scalafmt' and update the version to 1.5.1 since version 1.5.0 seems to have an invalid pom file (see https://plugins.gradle.org/m2/gradle/plugin/cz/alenkacz/gradle-scalafmt/1.5.0/gradle-scalafmt-1.5.0.pom) and refused to function. The version 1.5.1 seem to work fine (see https://plugins.gradle.org/m2/gradle/plugin/cz/alenkacz/gradle-scalafmt/1.5.1/gradle-scalafmt-1.5.1.pom).